### PR TITLE
Better design for quick actions

### DIFF
--- a/src/calculator/AddEquation.module.css
+++ b/src/calculator/AddEquation.module.css
@@ -23,7 +23,6 @@
   flex-direction: column;
   background-color: var(--dialog);
   border-radius: 5px;
-  overflow: hidden;
   box-shadow: 0 3px 10px rgba(0, 0, 0, 0.3);
 }
 .addType {
@@ -33,6 +32,14 @@
 }
 .addType:hover {
   background-color: var(--button-hover);
+}
+.addType:first-child {
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+}
+.addType:last-child {
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
 }
 .addType .icon {
   margin-right: 10px;

--- a/src/equation/Equation.jsx
+++ b/src/equation/Equation.jsx
@@ -23,7 +23,6 @@ class Equation extends React.Component {
   }
 
   state = {
-    showQuickActions: false,
     showInfo: true
   }
 
@@ -33,15 +32,6 @@ class Equation extends React.Component {
 
   componentDidUpdate () {
     katex.render(this.props.latex, this.previewRef, { throwOnError: false })
-  }
-
-  handleHideQuickActions = () => {
-    this.setState({ showQuickActions: false })
-  }
-
-  handleShowQuickActions = e => {
-    e.stopPropagation()
-    this.setState({ showQuickActions: true })
   }
 
   handleToggleInfoVisibility = () => {
@@ -69,7 +59,7 @@ class Equation extends React.Component {
   }
 
   render () {
-    const { showInfo, showQuickActions } = this.state
+    const { showInfo } = this.state
     const { equation, color, lineStyle, hidden, error } = this.props
     return (
       <li
@@ -79,27 +69,18 @@ class Equation extends React.Component {
           `color-${color}`
         )}
       >
-        <div
-          className={classNames(
-            styles.preview,
-            hidden && styles.hidden,
-            showQuickActions && styles.showQuickActions
-          )}
-          onClick={this.handleHideQuickActions}
-        >
-          <QuickActions
-            onToggleVisibility={this.handleTogglePlotVisibility}
-            onRemove={this.handleRemove}
-            hidden={hidden}
-          />
-          <div
-            className={styles.colorStrip}
-            onClick={this.handleShowQuickActions}
-          />
+        <div className={classNames(styles.preview, hidden && styles.hidden)}>
+          <div className={styles.colorStrip} />
           <button
             ref={this.setPreviewRef}
             className={styles.katexPreview}
             onClick={this.handleToggleInfoVisibility}
+          />
+          <QuickActions
+            hidden={hidden}
+            showingInfo={showInfo}
+            onToggleVisibility={this.handleTogglePlotVisibility}
+            onRemove={this.handleRemove}
           />
         </div>
         {showInfo && (

--- a/src/equation/Equation.module.css
+++ b/src/equation/Equation.module.css
@@ -8,9 +8,6 @@
   transition: transform 0.2s;
   min-height: 44px;
 }
-.showQuickActions {
-  transform: translateX(118px);
-}
 
 .colorStrip {
   width: 3px;

--- a/src/equation/QuickActions.jsx
+++ b/src/equation/QuickActions.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styles from './QuickActions.module.css'
-import { TrashcanIcon, EyeClosedIcon } from '@primer/octicons-react'
+import { XIcon, EyeIcon, EyeClosedIcon } from '@primer/octicons-react'
 import IconBtn from '../components/IconBtn.jsx'
 import { classNames } from '../utils/class-names.js'
 
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types'
 class QuickActions extends React.Component {
   static propTypes = {
     hidden: PropTypes.bool,
+    showingInfo: PropTypes.bool,
     onToggleVisibility: PropTypes.func.isRequired,
     onRemove: PropTypes.func.isRequired
   }
@@ -18,26 +19,31 @@ class QuickActions extends React.Component {
   }
 
   render () {
-    const { onToggleVisibility, onRemove, hidden } = this.props
+    const { onToggleVisibility, onRemove, hidden, showingInfo } = this.props
     return (
-      <div className={styles.wrapper}>
-        <div className={styles.quickActions} onClick={this.handleDontHide}>
-          <IconBtn
-            className={classNames(styles.quickAction, styles.danger)}
-            onClick={onRemove}
-          >
-            <TrashcanIcon aria-label='Remove' className={styles.icon} />
-          </IconBtn>
-          <IconBtn
-            className={classNames(
-              styles.quickAction,
-              hidden && styles.equationHidden
-            )}
-            onClick={onToggleVisibility}
-          >
-            <EyeClosedIcon aria-label='Hide' className={styles.icon} />
-          </IconBtn>
-        </div>
+      <div
+        className={classNames(
+          styles.quickActions,
+          showingInfo && styles.showingInfo
+        )}
+        onClick={this.handleDontHide}
+      >
+        <IconBtn
+          className={classNames(styles.quickAction, styles.removeBtn)}
+          onClick={onRemove}
+        >
+          <XIcon aria-label='Remove equation' className={styles.icon} />
+        </IconBtn>
+        <IconBtn
+          className={classNames(styles.quickAction, styles.visibilityBtn)}
+          onClick={onToggleVisibility}
+        >
+          {hidden ? (
+            <EyeClosedIcon aria-label='Show equation' className={styles.icon} />
+          ) : (
+            <EyeIcon aria-label='Hide equation' className={styles.icon} />
+          )}
+        </IconBtn>
       </div>
     )
   }

--- a/src/equation/QuickActions.module.css
+++ b/src/equation/QuickActions.module.css
@@ -1,36 +1,32 @@
-.wrapper {
-  position: relative;
-}
 .quickActions {
   display: flex;
-  position: absolute;
+  flex-direction: column;
   top: 0;
   bottom: 0;
   right: 0;
   align-items: center;
   z-index: 5;
-  padding: 0 5px;
+  padding: 5px;
 }
 .quickAction {
-  margin: 0 5px;
+  padding: 5px;
+  transition: opacity 0.2s, color 0.2s;
 }
 .quickAction:hover {
   background-color: var(--button-hover);
 }
-.quickAction.danger {
+.showingInfo .removeBtn,
+.removeBtn:hover {
   color: var(--danger);
 }
-.quickAction.danger:hover {
+.removeBtn:hover {
   background-color: var(--danger-hover);
 }
-.equationHidden {
-  background-color: var(--text);
-  color: var(--equation-background);
+.visibilityBtn {
+  opacity: 0;
 }
-.equationHidden:hover {
-  background-color: var(--text-hover);
-}
-.quickAction .icon {
-  width: 24px;
-  height: 24px;
+.showingInfo .visibilityBtn,
+.visibilityBtn:hover,
+.visibilityBtn:focus {
+  opacity: 1;
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/22133785/88728821-62183d80-d0e7-11ea-91fc-432ce48740d6.png)

After:
![image](https://user-images.githubusercontent.com/22133785/88728880-778d6780-d0e7-11ea-95fa-0a005dd698e9.png)

Hovering/focusing on the hide equation button while the equation info is collapsed will reveal it